### PR TITLE
fix error: index out of range

### DIFF
--- a/error.go
+++ b/error.go
@@ -24,11 +24,11 @@ type ErrorResponse struct {
 func (r *ErrorResponse) Error() string {
 	RequestID := r.RequestID
 	if RequestID == "" {
-		RequestID = r.Response.Header["X-Cos-Request-Id"][0]
+		RequestID = r.Response.Header.Get("X-Cos-Request-Id")
 	}
 	TraceID := r.TraceID
 	if TraceID == "" {
-		TraceID = r.Response.Header["X-Cos-Trace-Id"][0]
+		TraceID = r.Response.Header.Get("X-Cos-Trace-Id")
 	}
 	return fmt.Sprintf("%v %v: %d %v(Message: %v, RequestId: %v, TraceId: %v)",
 		r.Response.Request.Method, r.Response.Request.URL,


### PR DESCRIPTION
fix error.Error() method index out of range
```
panic: runtime error: index out of range
goroutine 243169 [running]:
github.com/tencentyun/cos-go-sdk-v5.(*ErrorResponse).Error(0xc424cb7c80, 0xc423dca6e0, 0xc4236230a0)
 /tmp/govendor/src/github.com/tencentyun/cos-go-sdk-v5/error.go:27 +0x331
```