### PR TITLE
fix: 修复示例中的错误

### DIFF
--- a/example/object/get.go
+++ b/example/object/get.go
@@ -3,25 +3,35 @@ package main
 import (
 	"context"
 	"fmt"
-	"net/url"
-	"os"
-
 	"io"
 	"io/ioutil"
-
 	"net/http"
+	"net/url"
+	"os"
 
 	"github.com/tencentyun/cos-go-sdk-v5"
 	"github.com/tencentyun/cos-go-sdk-v5/debug"
 )
 
+func panicError(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
 func main() {
+	secretID := os.Getenv("COS_SECRETID")
+	secretKey := os.Getenv("COS_SECRETKEY")
+	if secretID == "" || secretKey == "" {
+		panic("COS_SECRETID or COS_SECRETKEY is invalid")
+	}
+
 	u, _ := url.Parse("https://test-1253846586.cos.ap-guangzhou.myqcloud.com")
 	b := &cos.BaseURL{BucketURL: u}
 	c := cos.NewClient(b, &http.Client{
 		Transport: &cos.AuthorizationTransport{
-			SecretID:  os.Getenv("COS_SECRETID"),
-			SecretKey: os.Getenv("COS_SECRETKEY"),
+			SecretID:  secretID,
+			SecretKey: secretKey,
 			Transport: &debug.DebugRequestTransport{
 				RequestHeader:  true,
 				RequestBody:    true,
@@ -32,33 +42,27 @@ func main() {
 	})
 
 	// Case1 Download object into ReadCloser(). the body needs to be closed
-	name := "test/hello.txt"
+	name := "test1.txt"
 	resp, err := c.Object.Get(context.Background(), name, nil)
-	if err != nil {
-		panic(err)
-	}
+	panicError(err)
+
 	bs, _ := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 	fmt.Printf("%s\n", string(bs))
 
 	// Case2 Download object to local file. the body needs to be closed
 	fd, err := os.OpenFile("hello.txt", os.O_WRONLY|os.O_CREATE, 0660)
-	if err != nil {
-		panic(err)
-	}
+	panicError(err)
+
 	defer fd.Close()
 	resp, err = c.Object.Get(context.Background(), name, nil)
-	if err != nil {
-		panic(err)
-	}
+	panicError(err)
 	io.Copy(fd, resp.Body)
 	resp.Body.Close()
 
 	// Case3 Download object to local file path
-	err = c.Object.GetToFile(context.Background(), name, "hello_1.txt", nil)
-	if err != nil {
-		panic(err)
-	}
+	_, err = c.Object.GetToFile(context.Background(), name, "hello_1.txt", nil)
+	panicError(err)
 
 	// Case4 Download object with range header, can used to concurrent download
 	opt := &cos.ObjectGetOptions{
@@ -66,9 +70,7 @@ func main() {
 		Range:               "bytes=0-3",
 	}
 	resp, err = c.Object.Get(context.Background(), name, opt)
-	if err != nil {
-		panic(err)
-	}
+	panicError(err)
 	bs, _ = ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 	fmt.Printf("%s\n", string(bs))


### PR DESCRIPTION
- 示例中，Object.Get()返回值只接收了1个，实际函数返回两个返回值
- 规范import的顺序
- 增加panicError函数，避免大量的、重复的if err!= nil { panic(err) }
- 当环境变量不包括COS_SECRETID和COS_SECRETKEY时，报错

fix: #36