### PR TITLE
分片下载支持ProgressEvent

### DIFF
--- a/progress.go
+++ b/progress.go
@@ -71,6 +71,7 @@ func (r *teeReader) Read(p []byte) (int, error) {
 		event := newProgressEvent(ProgressFailedEvent, 0, r.consumedBytes, r.totalBytes, err)
 		progressCallback(r.listener, event)
 	}
+
 	if n > 0 {
 		r.consumedBytes += int64(n)
 		if r.writer != nil {


### PR DESCRIPTION
确实，分片下载的ProgressEvent如果要聚合有很多问题。

- range request里面没有content-length header
- 从object.client.Get的TeeReader触发的hook里的写入进度在数据准确性校验之前是无效的
- 大部分chunk没有completed事件

个人觉得，在分片下载ProgressEvent接入中，因为实现上就是分chunk并行下载，所以ProgressEvent的hook在推进度的时候符合真实的下载进度就可以了。
比如

- 当部分chunk数据校验错误，需要重试，此时ProgressEvent的ConsumedBytes应当能够正常退回到chunk重试时的ConsumedBytes
- 当部分chunk下载失败报错时，ProgressEventListener应当能够接收到chunk download error

在这个前提下，分片下载支持ProgressEvent是可行的。

我自己实现了这个部分，并在公司内部的工具中提供了这个能力（内网pod在线java dump，文件传到了cos，然后几个G走没有checkpoint下载失败过于痛苦）。觉得可以贡献出来。

相关的UT代码
https://github.com/athlum/cos-go-sdk-v5/blob/feature/multipart-download-with-progress-event/object_test.go#L1012

以下是UT记录

![image](https://user-images.githubusercontent.com/7090987/208647017-caee28ec-de72-4105-a185-525e73b457bd.png)

![image](https://user-images.githubusercontent.com/7090987/208647247-bd5ac8f5-2417-4108-8700-340f624924a6.png)
